### PR TITLE
Move vue to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,11 @@
     "vue directive",
     "directive"
   ],
-  "dependencies": {
-    "vue": "^2.6.11"
-  },
+  "dependencies": {},
   "devDependencies": {
     "rollup": "1.32.0",
     "rollup-plugin-terser": "5.2.0",
-    "typescript": "3.8.3"
+    "typescript": "3.8.3",
+    "vue": "^2.6.11"
   }
 }


### PR DESCRIPTION
Importing Vue as a dependency can be problematic. In development mode, Vue throws warning messages about `$listeners is readonly`. By moving Vue to `devDependencies`, the warning messages never appear again.